### PR TITLE
[Implementation] Use move api for rename

### DIFF
--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -216,6 +216,7 @@
                   <include>com.google.cloud.bigdataoss</include>
                   <include>com.google.cloud.grpc</include>
                   <include>com.google.cloud.http</include>
+                  <include>com.google.cloud.opentelemetry</include>
                   <include>com.google.flogger</include>
                   <include>com.google.code.gson</include>
                   <include>com.google.guava</include>
@@ -227,6 +228,9 @@
                   <include>com.lmax</include>
                   <include>io.grpc</include>
                   <include>io.opencensus</include>
+                  <include>io.opentelemetry</include>
+                  <include>io.opentelemetry.contrib</include>
+                  <include>io.opentelemetry.semconv</include>
                   <include>io.perfmark</include>
                   <include>org.apache.httpcomponents</include>
                   <include>org.threeten:threetenbp</include>
@@ -248,6 +252,7 @@
                     <include>com.google.cloud.hadoop.util.**</include>
                     <include>com.google.cloud.http.**</include>
                     <include>com.google.cloud.monitoring.**</include>
+                    <include>com.google.cloud.opentelemetry.**</include>
                     <include>com.google.cloud.spi.**</include>
                     <include>com.google.cloud.storage.**</include>
                     <include>com.google.common.**</include>

--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java
@@ -556,6 +556,14 @@ public class GoogleHadoopFileSystemConfiguration {
           "fs.gs.write.parallel.composite.upload.part.file.name.prefix",
           AsyncWriteChannelOptions.DEFAULT.getPartFileNamePrefix());
 
+  /**
+   * Configuration key for enabling move operation in gcs instead of copy+delete.
+   */
+  public static final HadoopConfigurationProperty<Boolean> GCS_OPERATION_MOVE_ENABLE =
+      new HadoopConfigurationProperty<>(
+          "fs.gs.operation.move.enable",
+          GoogleCloudStorageOptions.DEFAULT.isMoveOperationEnabled());
+
   static GoogleCloudStorageFileSystemOptions.Builder getGcsFsOptionsBuilder(Configuration config) {
     return GoogleCloudStorageFileSystemOptions.builder()
         .setBucketDeleteEnabled(GCE_BUCKET_DELETE_ENABLE.get(config, config::getBoolean))
@@ -618,7 +626,8 @@ public class GoogleHadoopFileSystemConfiguration {
         .setTraceLogEnabled(GCS_TRACE_LOG_ENABLE.get(config, config::getBoolean))
         .setOperationTraceLogEnabled(GCS_OPERATION_TRACE_LOG_ENABLE.get(config, config::getBoolean))
         .setTrafficDirectorEnabled(GCS_GRPC_TRAFFICDIRECTOR_ENABLE.get(config, config::getBoolean))
-        .setWriteChannelOptions(getWriteChannelOptions(config));
+        .setWriteChannelOptions(getWriteChannelOptions(config))
+        .setMoveOperationEnabled(GCS_OPERATION_MOVE_ENABLE.get(config, config::getBoolean));
   }
 
   @VisibleForTesting

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfigurationTest.java
@@ -127,6 +127,7 @@ public class GoogleHadoopFileSystemConfigurationTest {
               "fs.gs.write.parallel.composite.upload.part.file.cleanup.type",
               PartFileCleanupType.ALWAYS);
           put("fs.gs.write.parallel.composite.upload.part.file.name.prefix", "");
+          put("fs.gs.operation.move.enable", false);
         }
       };
 

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationTest.java
@@ -223,6 +223,39 @@ public abstract class GoogleHadoopFileSystemIntegrationTest extends GoogleHadoop
   }
 
   @Test
+  public void testRenameWithMoveOperation() throws Exception {
+    String bucketName = this.gcsiHelper.getUniqueBucketName("move");
+    GoogleHadoopFileSystem googleHadoopFileSystem = new GoogleHadoopFileSystem();
+
+    URI initUri = new URI("gs://" + bucketName);
+    Configuration config = loadConfig();
+    config.setBoolean("fs.gs.operation.move.enable", true);
+    googleHadoopFileSystem.initialize(initUri, config);
+
+    try {
+      GoogleCloudStorageFileSystemIntegrationHelper helper =
+          new HadoopFileSystemIntegrationHelper(googleHadoopFileSystem);
+
+      renameHelper(
+          new HdfsBehavior() {
+            /**
+             * Returns the MethodOutcome of trying to rename an existing file into the root
+             * directory.
+             */
+            @Override
+            public MethodOutcome renameFileIntoRootOutcome() {
+              return new MethodOutcome(MethodOutcome.Type.RETURNS_TRUE);
+            }
+          },
+          bucketName,
+          bucketName,
+          helper);
+    } finally {
+      googleHadoopFileSystem.delete(new Path(initUri));
+    }
+  }
+
+  @Test
   public void testInitializePath_success() throws Exception {
     List<String> validPaths = Arrays.asList("gs://foo", "gs://foo/bar");
     for (String path : validPaths) {

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemTest.java
@@ -390,6 +390,9 @@ public class GoogleHadoopFileSystemTest extends GoogleHadoopFileSystemIntegratio
   public void testRenameHnBucket() {}
 
   @Override
+  public void testRenameWithMoveOperation() {}
+
+  @Override
   public void testGcsJsonAPIMetrics() {}
 
   @Override

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
@@ -153,6 +153,14 @@ public class ForwardingGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
+  public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException {
+    logger.atFiner().log("%s.move(%s)", delegateClassName, sourceToDestinationObjectsMap);
+    delegate.copy(sourceToDestinationObjectsMap);
+  }
+
+
+  @Override
   public boolean isHnBucket(URI src) throws IOException {
     return delegate.isHnBucket(src);
   }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorage.java
@@ -156,7 +156,7 @@ public class ForwardingGoogleCloudStorage implements GoogleCloudStorage {
   public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
       throws IOException {
     logger.atFiner().log("%s.move(%s)", delegateClassName, sourceToDestinationObjectsMap);
-    delegate.copy(sourceToDestinationObjectsMap);
+    delegate.move(sourceToDestinationObjectsMap);
   }
 
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
@@ -282,6 +282,18 @@ public interface GoogleCloudStorage {
   }
 
   /**
+   * Moves metadata of the given objects. Moving between two different locations or between two
+   * different storage classes is not allowed.
+   *
+   * @param sourceToDestinationObjectsMap map of destination objects to be moved, keyed by source
+   * @throws java.io.FileNotFoundException if the source object or the destination bucket does not
+   *     exist
+   * @throws IOException in all other error cases
+   */
+  void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException;
+
+  /**
    * Checks if {@code resourceId} belongs to a Hierarchical namespace enabled bucket. This takes a
    * path and not the bucket name since the caller may not have permission to query the bucket.
    *

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorage.java
@@ -282,8 +282,7 @@ public interface GoogleCloudStorage {
   }
 
   /**
-   * Moves metadata of the given objects. Moving between two different locations or between two
-   * different storage classes is not allowed.
+   * Moves metadata of the given objects. Moving between two different buckets is not allowed.
    *
    * @param sourceToDestinationObjectsMap map of destination objects to be moved, keyed by source
    * @throws java.io.FileNotFoundException if the source object or the destination bucket does not

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientImpl.java
@@ -481,7 +481,7 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
     copy(sourceToDestinationObjectsMap);
   }
 
-  /** See {@link GoogleCloudStorage#move(Map)} for details about expected behavior. */
+  /** See {@link GoogleCloudStorage#move(Map<StorageResourceId, StorageResourceId>)} for details about expected behavior. */
   @Override
   public void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
       throws IOException {
@@ -554,8 +554,8 @@ public class GoogleCloudStorageClientImpl extends ForwardingGoogleCloudStorage {
             String srcString = StringPaths.fromComponents(srcBucketName, srcObjectName);
             String dstString = StringPaths.fromComponents(srcBucketName, dstObjectName);
 
-            Blob blob = storage.moveBlob(moveRequestBuilder.build());
-            if (blob.exists()) {
+            Blob movedBlob = storage.moveBlob(moveRequestBuilder.build());
+            if (movedBlob != null) {
               logger.atFiner().log("Successfully moved %s to %s", srcString, dstString);
             }
           } catch (StorageException e) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
@@ -616,7 +616,7 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
               dst, /* allowEmptyObjectName= */ true, /* generationId= */ 0L);
 
       if(this.options.getCloudStorageOptions().isMoveOperationEnabled() &&
-          srcResourceId.getBucketName() == dstResourceId.getBucketName()) {
+          srcResourceId.getBucketName().equals(dstResourceId.getBucketName()) ) {
         gcs.move(ImmutableMap.of(srcResourceId, dstResourceId));
       } else {
         gcs.copy(ImmutableMap.of(srcResourceId, dstResourceId));
@@ -776,10 +776,10 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
         StorageResourceId.fromUriPath(
             dst, /* allowEmptyObjectName= */ true, /* generationId= */ 0L);
     if(this.options.getCloudStorageOptions().isMoveOperationEnabled() &&
-        srcResourceId.getBucketName() == dstResourceId.getBucketName()) {
-      // First, copy all items except marker items
+        srcResourceId.getBucketName().equals(dstResourceId.getBucketName())) {
+      // First, move all items except marker items
       moveInternal(srcToDstItemNames);
-      // Finally, copy marker items (if any) to mark rename operation success
+      // Finally, move marker items (if any) to mark rename operation success
       moveInternal(srcToDstMarkerItemNames);
       return;
     }

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
@@ -614,14 +614,19 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
           StorageResourceId.fromUriPath(
               dst, /* allowEmptyObjectName= */ true, /* generationId= */ 0L);
 
-      gcs.copy(ImmutableMap.of(srcResourceId, dstResourceId));
+      if(this.options.getCloudStorageOptions().isMoveOperationEnabled() &&
+          srcResourceId.getBucketName() == dstResourceId.getBucketName()) {
+        gcs.move(ImmutableMap.of(srcResourceId, dstResourceId));
+      } else {
+        gcs.copy(ImmutableMap.of(srcResourceId, dstResourceId));
 
-      gcs.deleteObjects(
-          ImmutableList.of(
-              new StorageResourceId(
-                  srcInfo.getItemInfo().getBucketName(),
-                  srcInfo.getItemInfo().getObjectName(),
-                  srcInfo.getItemInfo().getContentGeneration())));
+        gcs.deleteObjects(
+            ImmutableList.of(
+                new StorageResourceId(
+                    srcInfo.getItemInfo().getBucketName(),
+                    srcInfo.getItemInfo().getObjectName(),
+                    srcInfo.getItemInfo().getContentGeneration())));
+      }
     }
 
     repairImplicitDirectory(srcParentInfoFuture);

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemImpl.java
@@ -777,9 +777,9 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
             dst, /* allowEmptyObjectName= */ true, /* generationId= */ 0L);
     if(this.options.getCloudStorageOptions().isMoveOperationEnabled() &&
         srcResourceId.getBucketName() == dstResourceId.getBucketName()) {
-      // First, copy all items except marker items
+      // First, move all items except marker items
       moveInternal(srcToDstItemNames);
-      // Finally, copy marker items (if any) to mark rename operation success
+      // Finally, move marker items (if any) to mark rename operation success
       moveInternal(srcToDstMarkerItemNames);
       return;
     }
@@ -841,7 +841,7 @@ public class GoogleCloudStorageFileSystemImpl implements GoogleCloudStorageFileS
       return;
     }
 
-    Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap = new HashMap<>(0);
+    Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap = new HashMap<>();
 
     // Prepare list of items to move.
     for (Map.Entry<FileInfo, URI> srcToDstItemName : srcToDstItemNames.entrySet()) {

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java
@@ -1123,7 +1123,7 @@ public class GoogleCloudStorageImpl implements GoogleCloudStorage {
 
     String traceContext = String.format("batchmove(size=%s)", sourceToDestinationObjectsMap.size());
     try (ITraceOperation to = TraceOperation.addToExistingTrace(traceContext)) {
-      // Perform the copy operations.
+      // Perform the move operations.
 
       BatchHelper batchHelper =
           batchFactory.newBatchHelper(

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageOptions.java
@@ -66,7 +66,8 @@ public abstract class GoogleCloudStorageOptions {
         .setTrafficDirectorEnabled(true)
         .setWriteChannelOptions(AsyncWriteChannelOptions.DEFAULT)
         .setHnBucketRenameEnabled(false)
-        .setGrpcWriteEnabled(false);
+        .setGrpcWriteEnabled(false)
+        .setMoveOperationEnabled(false);
   }
 
   public abstract Builder toBuilder();
@@ -144,6 +145,8 @@ public abstract class GoogleCloudStorageOptions {
   public abstract boolean isTraceLogEnabled();
 
   public abstract boolean isOperationTraceLogEnabled();
+
+  public abstract boolean isMoveOperationEnabled();
 
   public RetryHttpInitializerOptions toRetryHttpInitializerOptions() {
     return RetryHttpInitializerOptions.builder()
@@ -231,6 +234,8 @@ public abstract class GoogleCloudStorageOptions {
     public abstract Builder setHnBucketRenameEnabled(boolean enabled);
 
     public abstract Builder setGrpcWriteEnabled(boolean grpcWriteEnabled);
+
+    public abstract Builder setMoveOperationEnabled(boolean moveOperationEnabled);
 
     abstract GoogleCloudStorageOptions autoBuild();
 

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/testing/InMemoryGoogleCloudStorage.java
@@ -327,6 +327,12 @@ public class InMemoryGoogleCloudStorage implements GoogleCloudStorage {
   }
 
   @Override
+  public synchronized void move(Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap)
+      throws IOException {
+    throw new IOException("Not implemented");
+  }
+
+  @Override
   public synchronized void copy(
       String srcBucketName,
       List<String> srcObjectNames,

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/ForwardingGoogleCloudStorageTest.java
@@ -25,7 +25,9 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -217,6 +219,18 @@ public class ForwardingGoogleCloudStorageTest {
 
     verify(mockGcsDelegate)
         .copy(eq(TEST_STRING), eq(TEST_STRINGS), eq(TEST_STRING), eq(TEST_STRINGS));
+  }
+
+  @Test
+  public void testMove() throws IOException {
+    Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap =
+        new HashMap<>(TEST_STRINGS.size());
+      sourceToDestinationObjectsMap.put(
+          new StorageResourceId(TEST_STRING, TEST_STRING),
+          new StorageResourceId(TEST_STRING, TEST_STRING));
+    gcs.move(sourceToDestinationObjectsMap);
+
+    verify(mockGcsDelegate).move(eq(sourceToDestinationObjectsMap));
   }
 
   @Test

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageClientTest.java
@@ -145,20 +145,19 @@ public class GoogleCloudStorageClientTest {
           .setSize(1234)
           .build();
 
-  // Object representing the state *after* a successful move
   private static final Object MOVED_OBJECT =
       TEST_OBJECT.toBuilder()
-          .setName(DEST_OBJECT_NAME) // Name changed
-          .setGeneration(GENERATION + 1) // Generation likely changes
-          .setMetageneration(1L) // Metageneration resets or changes
+          .setName(DEST_OBJECT_NAME)
+          .setGeneration(GENERATION + 1)
+          .setMetageneration(1L)
           .build();
 
   private static final Object MOVED_OBJECT_2 =
       TEST_OBJECT.toBuilder()
-          .setName(DEST_OBJECT_NAME_2) // Name changed
+          .setName(DEST_OBJECT_NAME_2)
           .setBucket(BucketName.of("", TEST_BUCKET_NAME).toString())
-          .setGeneration(GENERATION + 2) // Generation likely changes
-          .setMetageneration(1L) // Metageneration resets or changes
+          .setGeneration(GENERATION + 2)
+          .setMetageneration(1L)
           .build();
 
   private static MockHttpTransport transport = mockTransport();
@@ -521,8 +520,8 @@ public class GoogleCloudStorageClientTest {
   @Test
   public void move_succeedsMultipleObjects() throws Exception {
     // Mock responses for two move operations
-    mockStorage.addResponse(MOVED_OBJECT); // Response for moving TEST_RESOURCE_ID
-    mockStorage.addResponse(MOVED_OBJECT_2); // Response for moving TEST_RESOURCE_ID_2
+    mockStorage.addResponse(MOVED_OBJECT);
+    mockStorage.addResponse(MOVED_OBJECT_2);
 
     Map<StorageResourceId, StorageResourceId> moveMap =
         ImmutableMap.of(
@@ -569,10 +568,9 @@ public class GoogleCloudStorageClientTest {
                 + " is still available but the requested generation is deleted.",
             TEST_RESOURCE_ID.toString()));
       } catch (Exception e) {
-      // Catch other exceptions to fail the test explicitly if something else goes wrong
       fail("Expected FileNotFoundException but got " + e.getClass().getName());
     }
-      assertEquals(mockStorage.getRequests().size(), 0); // The failed move attempt
+      assertEquals(mockStorage.getRequests().size(), 0);
     }
 
   @Test
@@ -600,7 +598,7 @@ public class GoogleCloudStorageClientTest {
         // Catch other exceptions to fail the test explicitly if something else goes wrong
         fail("Expected IOException but got " + e.getClass().getName());
     }
-    assertEquals(mockStorage.getRequests().size(), 0); // The failed move attempt
+    assertEquals(mockStorage.getRequests().size(), 0);
   }
 
   @Test
@@ -611,7 +609,7 @@ public class GoogleCloudStorageClientTest {
       GoogleCloudStorage gcs =
           mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
 
-      gcs.move(moveMap); // Should not throw
+      gcs.move(moveMap);
     }
     assertEquals(mockStorage.getRequests().size(), 0); // No requests should be sent
   }
@@ -626,7 +624,7 @@ public class GoogleCloudStorageClientTest {
       GoogleCloudStorage gcs =
           mockedGcsClientImpl(transport, fakeServer.getGrpcStorageOptions().getService());
 
-        gcs.move(moveMap); // Call the method expected to throw
+        gcs.move(moveMap);
         fail("Expected UnsupportedOperationException was not thrown.");
       } catch (UnsupportedOperationException e) {
         // Exception was caught as expected, now assert the message
@@ -637,7 +635,7 @@ public class GoogleCloudStorageClientTest {
       // Catch other exceptions to fail the test explicitly if something else goes wrong
       fail("Expected UnsupportedOperationException but got " + e.getClass().getName());
     }
-    assertEquals(mockStorage.getRequests().size(), 0); // Validation fails before request
+    assertEquals(mockStorage.getRequests().size(), 0);
   }
 
   @Test
@@ -661,7 +659,7 @@ public class GoogleCloudStorageClientTest {
     assertThat(actualRequest.getDestinationObject()).isEqualTo(DEST_OBJECT_NAME);
     assertThat(actualRequest.getSourceObject()).contains(TEST_OBJECT_NAME);
     assertThat(actualRequest.getBucket()).contains(TEST_BUCKET_NAME);
-    // Assert generation condition *was* set
+    // Assert generation condition was set
    assertThat(actualRequest.getIfGenerationMatch()).isEqualTo(DEST_RESOURCE_ID_WITH_GEN.getGenerationId());
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -1995,7 +1995,7 @@ public class GoogleCloudStorageTest {
         .inOrder();
   }
 
-  /** Test argument sanitization for GoogleCloudStorage.move(4). */
+  /** Test argument sanitization for GoogleCloudStorage.move(1). */
   @Test
   public void testMoveObjectsIllegalArguments() throws IOException {
     String b = BUCKET_NAME;
@@ -2012,7 +2012,7 @@ public class GoogleCloudStorageTest {
         new StorageResourceId(b, o));
     assertThrows(IllegalArgumentException.class, () -> gcs.move(sourceToDestinationObjectsMap));
 
-    // Null Objects.
+    // Failure if srcBucket != dstBucket.
     sourceToDestinationObjectsMap.clear();
     sourceToDestinationObjectsMap.put(
         new StorageResourceId(b, o),
@@ -2021,7 +2021,7 @@ public class GoogleCloudStorageTest {
   }
 
   /**
-   * Test successful operation of GoogleCloudStorage.move(4).
+   * Test successful operation of GoogleCloudStorage.move(1).
    */
   @Test
   public void testMoveObjectsOperation() throws IOException {

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -2006,28 +2006,7 @@ public class GoogleCloudStorageTest {
     Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap =
         new HashMap<>();
 
-
-    ILLEGAL_OBJECTS.forEach(
-        objectPair -> {
-          String badBucket = objectPair[0];
-          String badObject = objectPair[1];
-          // Src is bad.
-          sourceToDestinationObjectsMap.put(
-              new StorageResourceId(b, badObject),
-              new StorageResourceId(b, o));
-          assertThrows(IllegalArgumentException.class, () -> gcs.move(sourceToDestinationObjectsMap));
-
-          // Dst is bad.
-          sourceToDestinationObjectsMap.clear();
-          sourceToDestinationObjectsMap.put(
-              new StorageResourceId(b, o),
-              new StorageResourceId(b, badObject));
-
-          assertThrows(IllegalArgumentException.class, () -> gcs.move(sourceToDestinationObjectsMap));
-        });
-
     // Failure if src == dst.
-    sourceToDestinationObjectsMap.clear();
     sourceToDestinationObjectsMap.put(
         new StorageResourceId(b, o),
         new StorageResourceId(b, o));
@@ -2036,14 +2015,9 @@ public class GoogleCloudStorageTest {
     // Null Objects.
     sourceToDestinationObjectsMap.clear();
     sourceToDestinationObjectsMap.put(
-        new StorageResourceId(b, null),
-        new StorageResourceId(b, o));
-    assertThrows(IllegalArgumentException.class, () -> gcs.move(sourceToDestinationObjectsMap));
-    sourceToDestinationObjectsMap.clear();
-    sourceToDestinationObjectsMap.put(
         new StorageResourceId(b, o),
-        new StorageResourceId(b, null));
-    assertThrows(IllegalArgumentException.class, () -> gcs.move(sourceToDestinationObjectsMap));
+        new StorageResourceId("other-bucket", o));
+    assertThrows(UnsupportedOperationException.class, () -> gcs.move(sourceToDestinationObjectsMap));
   }
 
   /**

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageTest.java
@@ -33,6 +33,7 @@ import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getMe
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.getRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.listBucketsRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.listRequestWithTrailingDelimiter;
+import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.moveRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.resumableUploadChunkRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.resumableUploadRequestString;
 import static com.google.cloud.hadoop.gcsio.TrackingHttpRequestInitializer.uploadRequestString;
@@ -1991,6 +1992,84 @@ public class GoogleCloudStorageTest {
     assertThat(trackingRequestInitializerWithRetries.getAllRequestStrings())
         .containsExactly(
             copyRequestString(BUCKET_NAME, OBJECT_NAME, BUCKET_NAME, dstObject, "copyTo"))
+        .inOrder();
+  }
+
+  /** Test argument sanitization for GoogleCloudStorage.move(4). */
+  @Test
+  public void testMoveObjectsIllegalArguments() throws IOException {
+    String b = BUCKET_NAME;
+    String o = OBJECT_NAME;
+
+    GoogleCloudStorage gcs = mockedGcsImpl(HTTP_TRANSPORT);
+
+    Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap =
+        new HashMap<>();
+
+
+    ILLEGAL_OBJECTS.forEach(
+        objectPair -> {
+          String badBucket = objectPair[0];
+          String badObject = objectPair[1];
+          // Src is bad.
+          sourceToDestinationObjectsMap.put(
+              new StorageResourceId(b, badObject),
+              new StorageResourceId(b, o));
+          assertThrows(IllegalArgumentException.class, () -> gcs.move(sourceToDestinationObjectsMap));
+
+          // Dst is bad.
+          sourceToDestinationObjectsMap.clear();
+          sourceToDestinationObjectsMap.put(
+              new StorageResourceId(b, o),
+              new StorageResourceId(b, badObject));
+
+          assertThrows(IllegalArgumentException.class, () -> gcs.move(sourceToDestinationObjectsMap));
+        });
+
+    // Failure if src == dst.
+    sourceToDestinationObjectsMap.clear();
+    sourceToDestinationObjectsMap.put(
+        new StorageResourceId(b, o),
+        new StorageResourceId(b, o));
+    assertThrows(IllegalArgumentException.class, () -> gcs.move(sourceToDestinationObjectsMap));
+
+    // Null Objects.
+    sourceToDestinationObjectsMap.clear();
+    sourceToDestinationObjectsMap.put(
+        new StorageResourceId(b, null),
+        new StorageResourceId(b, o));
+    assertThrows(IllegalArgumentException.class, () -> gcs.move(sourceToDestinationObjectsMap));
+    sourceToDestinationObjectsMap.clear();
+    sourceToDestinationObjectsMap.put(
+        new StorageResourceId(b, o),
+        new StorageResourceId(b, null));
+    assertThrows(IllegalArgumentException.class, () -> gcs.move(sourceToDestinationObjectsMap));
+  }
+
+  /**
+   * Test successful operation of GoogleCloudStorage.move(4).
+   */
+  @Test
+  public void testMoveObjectsOperation() throws IOException {
+    String dstObject = OBJECT_NAME + "-move";
+    StorageObject object = newStorageObject(BUCKET_NAME, dstObject);
+    MockHttpTransport transport =
+        mockTransport(jsonDataResponse(new Objects().setItems(ImmutableList.of(object))));
+
+    GoogleCloudStorage gcs =
+        mockedGcsImpl(GCS_OPTIONS, transport, trackingRequestInitializerWithRetries);
+
+    Map<StorageResourceId, StorageResourceId> sourceToDestinationObjectsMap =
+        new HashMap<>(1);
+    sourceToDestinationObjectsMap.put(
+        new StorageResourceId(BUCKET_NAME, OBJECT_NAME),
+        new StorageResourceId(BUCKET_NAME, dstObject));
+
+    gcs.move(sourceToDestinationObjectsMap);
+
+    assertThat(trackingRequestInitializerWithRetries.getAllRequestStrings())
+        .containsExactly(
+            moveRequestString(BUCKET_NAME, OBJECT_NAME, dstObject, "moveTo"))
         .inOrder();
   }
 

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/MockStorage.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/MockStorage.java
@@ -20,6 +20,8 @@ import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.Empty;
 import com.google.storage.v2.Bucket;
 import com.google.storage.v2.ComposeObjectRequest;
+import com.google.storage.v2.MoveObjectRequest; // <-- Add this import
+import com.google.storage.v2.Object;
 import com.google.storage.v2.CreateBucketRequest;
 import com.google.storage.v2.DeleteBucketRequest;
 import com.google.storage.v2.DeleteObjectRequest;
@@ -278,5 +280,24 @@ final class MockStorage extends StorageImplBase {
       @Override
       public void onCompleted() {}
     };
+  }
+  @Override
+  public void moveObject(MoveObjectRequest request, StreamObserver<Object> responseObserver) {
+    java.lang.Object response = responses.poll(); // Get the next queued response/exception
+    if (response instanceof Object) { // Check if it's the expected success response type
+      requests.add(request); // Record the request
+      responseObserver.onNext(((Object) response)); // Send the successful response
+      responseObserver.onCompleted(); // Mark the RPC as complete
+    } else if (response instanceof Exception) { // Check if it's a queued exception
+      responseObserver.onError(((Exception) response)); // Send the error back to the client
+    } else { // Handle cases where an unexpected type was queued
+      responseObserver.onError(
+          new IllegalArgumentException(
+              String.format(
+                  "Unrecognized response type %s for method MoveObject, expected %s or %s",
+                  response == null ? "null" : response.getClass().getName(),
+                  Object.class.getName(), // Expected success type is Object proto
+                  Exception.class.getName())));
+    }
   }
 }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/MockStorage.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/MockStorage.java
@@ -20,7 +20,7 @@ import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.Empty;
 import com.google.storage.v2.Bucket;
 import com.google.storage.v2.ComposeObjectRequest;
-import com.google.storage.v2.MoveObjectRequest; // <-- Add this import
+import com.google.storage.v2.MoveObjectRequest;
 import com.google.storage.v2.Object;
 import com.google.storage.v2.CreateBucketRequest;
 import com.google.storage.v2.DeleteBucketRequest;
@@ -283,20 +283,20 @@ final class MockStorage extends StorageImplBase {
   }
   @Override
   public void moveObject(MoveObjectRequest request, StreamObserver<Object> responseObserver) {
-    java.lang.Object response = responses.poll(); // Get the next queued response/exception
-    if (response instanceof Object) { // Check if it's the expected success response type
-      requests.add(request); // Record the request
-      responseObserver.onNext(((Object) response)); // Send the successful response
-      responseObserver.onCompleted(); // Mark the RPC as complete
-    } else if (response instanceof Exception) { // Check if it's a queued exception
-      responseObserver.onError(((Exception) response)); // Send the error back to the client
-    } else { // Handle cases where an unexpected type was queued
+    java.lang.Object response = responses.poll();
+    if (response instanceof Object) {
+      requests.add(request);
+      responseObserver.onNext(((Object) response));
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError(((Exception) response));
+    } else {
       responseObserver.onError(
           new IllegalArgumentException(
               String.format(
                   "Unrecognized response type %s for method MoveObject, expected %s or %s",
                   response == null ? "null" : response.getClass().getName(),
-                  Object.class.getName(), // Expected success type is Object proto
+                  Object.class.getName(),
                   Exception.class.getName())));
     }
   }

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/TrackingHttpRequestInitializer.java
@@ -56,6 +56,9 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
   private static final String POST_COPY_REQUEST_FORMAT =
       "POST:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s/o/%s/%s/b/%s/o/%s";
 
+  private static final String POST_MOVE_REQUEST_FORMAT =
+      "POST:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s/o/%s/%s/o/%s";
+
   private static final String POST_COPY_REQUEST_WITH_METADATA_FORMAT =
       "POST:" + GOOGLEAPIS_ENDPOINT + "/storage/v1/b/%s/o/%s/%s/b/%s/o/%s?ifGenerationMatch=%s";
 
@@ -325,6 +328,16 @@ public class TrackingHttpRequestInitializer implements HttpRequestInitializer {
             urlEncode(dstObject),
             replaceGenerationId ? "generationId_" + generationId : generationId);
     return generationId == null ? request.replaceAll("ifGenerationMatch=[^&]+&", "") : request;
+  }
+
+  public static String moveRequestString(
+      String bucket, String srcObject, String dstObject, String requestType) {
+    return String.format(
+        POST_MOVE_REQUEST_FORMAT,
+        bucket,
+        urlEncode(srcObject),
+        requestType,
+        urlEncode(dstObject));
   }
 
   public static String uploadRequestString(String bucketName, String object, Integer generationId) {

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <google.api-client.version>2.1.1</google.api-client.version>
     <google.api-client-libraries.version>2.0.0</google.api-client-libraries.version>
     <google.api-iamcredentials.version>v1-rev20211203-${google.api-client-libraries.version}</google.api-iamcredentials.version>
-    <google.api-storage.version>v1-rev20240105-${google.api-client-libraries.version}</google.api-storage.version>
+    <google.api-storage.version>v1-rev20250312-${google.api-client-libraries.version}</google.api-storage.version>
     <google.api.grpc.proto-google-iam-v1.version>1.6.23</google.api.grpc.proto-google-iam-v1.version>
     <google.auth.version>1.33.1</google.auth.version>
     <google.auto-value.version>1.10.4</google.auto-value.version>


### PR DESCRIPTION
1. Implementation of move for JSON and gRPC client
2. Added config flag to switch to the new implementation
3. Added unit tests for the respective implementation
4. Added integration test

Testing :
1. Unit tests running 
2. Tested locally for JSON and gRPC for flat bucket and folder renames,with and without the flags